### PR TITLE
fix: add JSONDecodeError handling to agent config loaders

### DIFF
--- a/src/barbossa/agents/auditor.py
+++ b/src/barbossa/agents/auditor.py
@@ -105,8 +105,12 @@ class BarbossaAuditor:
     def _load_config(self) -> Dict:
         """Load repository configuration"""
         if self.config_file.exists():
-            with open(self.config_file, 'r') as f:
-                return json.load(f)
+            try:
+                with open(self.config_file, 'r') as f:
+                    return json.load(f)
+            except json.JSONDecodeError as e:
+                self.logger.error(f"Invalid JSON in config file {self.config_file}: {e}")
+                return {'repositories': []}
         self.logger.error(f"Config file not found: {self.config_file}")
         return {'repositories': []}
 

--- a/src/barbossa/agents/discovery.py
+++ b/src/barbossa/agents/discovery.py
@@ -108,8 +108,12 @@ class BarbossaDiscovery:
 
     def _load_config(self) -> Dict:
         if self.config_file.exists():
-            with open(self.config_file, 'r') as f:
-                return json.load(f)
+            try:
+                with open(self.config_file, 'r') as f:
+                    return json.load(f)
+            except json.JSONDecodeError as e:
+                self.logger.error(f"Invalid JSON in config file {self.config_file}: {e}")
+                return {'repositories': []}
         return {'repositories': []}
 
     def _run_cmd(self, cmd: str, cwd: str = None, timeout: int = 60) -> Optional[str]:

--- a/src/barbossa/agents/engineer.py
+++ b/src/barbossa/agents/engineer.py
@@ -112,8 +112,12 @@ class Barbossa:
     def _load_config(self) -> Dict:
         """Load repository configuration"""
         if self.config_file.exists():
-            with open(self.config_file, 'r') as f:
-                return json.load(f)
+            try:
+                with open(self.config_file, 'r') as f:
+                    return json.load(f)
+            except json.JSONDecodeError as e:
+                self.logger.error(f"Invalid JSON in config file {self.config_file}: {e}")
+                return {'repositories': []}
 
         self.logger.error(f"Config file not found: {self.config_file}")
         return {'repositories': []}

--- a/src/barbossa/agents/product.py
+++ b/src/barbossa/agents/product.py
@@ -105,8 +105,12 @@ class BarbossaProduct:
 
     def _load_config(self) -> Dict:
         if self.config_file.exists():
-            with open(self.config_file, 'r') as f:
-                return json.load(f)
+            try:
+                with open(self.config_file, 'r') as f:
+                    return json.load(f)
+            except json.JSONDecodeError as e:
+                self.logger.error(f"Invalid JSON in config file {self.config_file}: {e}")
+                return {'repositories': []}
         return {'repositories': []}
 
     def _run_cmd(self, cmd: str, cwd: str = None, timeout: int = 60) -> Optional[str]:

--- a/src/barbossa/agents/spec_generator.py
+++ b/src/barbossa/agents/spec_generator.py
@@ -109,8 +109,12 @@ class BarbossaSpecGenerator:
 
     def _load_config(self) -> Dict:
         if self.config_file.exists():
-            with open(self.config_file, 'r') as f:
-                return json.load(f)
+            try:
+                with open(self.config_file, 'r') as f:
+                    return json.load(f)
+            except json.JSONDecodeError as e:
+                self.logger.error(f"Invalid JSON in config file {self.config_file}: {e}")
+                return {'repositories': [], 'products': []}
         return {'repositories': [], 'products': []}
 
     def _run_cmd(self, cmd: str, cwd: str = None, timeout: int = 60) -> Optional[str]:

--- a/src/barbossa/agents/tech_lead.py
+++ b/src/barbossa/agents/tech_lead.py
@@ -147,8 +147,12 @@ class BarbossaTechLead:
     def _load_config(self) -> Dict:
         """Load repository configuration"""
         if self.config_file.exists():
-            with open(self.config_file, 'r') as f:
-                return json.load(f)
+            try:
+                with open(self.config_file, 'r') as f:
+                    return json.load(f)
+            except json.JSONDecodeError as e:
+                self.logger.error(f"Invalid JSON in config file {self.config_file}: {e}")
+                return {'repositories': []}
         self.logger.error(f"Config file not found: {self.config_file}")
         return {'repositories': []}
 

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Tests for agent config loading error handling.
+
+Verifies that all agents handle invalid JSON in config files gracefully
+instead of crashing with unhandled JSONDecodeError exceptions.
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add src directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+
+class TestConfigLoadingErrorHandling(unittest.TestCase):
+    """Test that agents handle invalid JSON config files gracefully."""
+
+    def setUp(self):
+        """Create a temporary directory with config subdirectory."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.config_dir = self.temp_dir / 'config'
+        self.config_dir.mkdir()
+        self.config_path = self.config_dir / 'repositories.json'
+        # Write invalid JSON that will trigger JSONDecodeError
+        self.config_path.write_text('{ invalid json content }')
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('barbossa.agents.discovery.logging')
+    def test_discovery_handles_invalid_json(self, mock_logging):
+        """Discovery agent should handle invalid JSON and raise ValueError for missing owner."""
+        from barbossa.agents.discovery import BarbossaDiscovery
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+
+        # With invalid JSON, the agent should log an error and then fail
+        # with a clean ValueError (owner required) instead of JSONDecodeError
+        with self.assertRaises(ValueError) as ctx:
+            BarbossaDiscovery(work_dir=self.temp_dir)
+
+        self.assertIn('owner', str(ctx.exception))
+        # Should have logged the JSON error before raising ValueError
+        mock_logger.error.assert_called()
+        error_call = mock_logger.error.call_args[0][0]
+        self.assertIn('Invalid JSON', error_call)
+
+    @patch('barbossa.agents.product.logging')
+    def test_product_handles_invalid_json(self, mock_logging):
+        """Product Manager agent should handle invalid JSON and raise ValueError for missing owner."""
+        from barbossa.agents.product import BarbossaProduct
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+
+        with self.assertRaises(ValueError) as ctx:
+            BarbossaProduct(work_dir=self.temp_dir)
+
+        self.assertIn('owner', str(ctx.exception))
+        mock_logger.error.assert_called()
+
+    @patch('barbossa.agents.spec_generator.logging')
+    def test_spec_generator_handles_invalid_json(self, mock_logging):
+        """Spec Generator agent should handle invalid JSON and raise ValueError for missing owner."""
+        from barbossa.agents.spec_generator import BarbossaSpecGenerator
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+
+        with self.assertRaises(ValueError) as ctx:
+            BarbossaSpecGenerator(work_dir=self.temp_dir)
+
+        self.assertIn('owner', str(ctx.exception))
+        mock_logger.error.assert_called()
+
+
+class TestValidJsonStillWorks(unittest.TestCase):
+    """Ensure valid JSON config files still load correctly."""
+
+    def setUp(self):
+        """Create temp dir with valid JSON config."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.config_dir = self.temp_dir / 'config'
+        self.config_dir.mkdir()
+        self.config_path = self.config_dir / 'repositories.json'
+        self.valid_config = {
+            'owner': 'test-owner',
+            'repositories': [
+                {'repo': 'test-repo', 'url': 'https://github.com/test/test'}
+            ]
+        }
+        self.config_path.write_text(json.dumps(self.valid_config))
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('barbossa.agents.discovery.logging')
+    def test_discovery_loads_valid_json(self, mock_logging):
+        """Discovery agent should load valid JSON correctly."""
+        from barbossa.agents.discovery import BarbossaDiscovery
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+
+        discovery = BarbossaDiscovery(work_dir=self.temp_dir)
+        config = discovery._load_config()
+
+        self.assertEqual(config['owner'], 'test-owner')
+        self.assertEqual(len(config['repositories']), 1)
+        # Should NOT log any errors for valid JSON
+        mock_logger.error.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

All six agents (Engineer, Tech Lead, Discovery, Product, Spec Generator, and Auditor) were missing error handling for `json.JSONDecodeError` in their `_load_config()` methods. If a config file contained malformed JSON, the agents would crash with an unhandled exception instead of logging the error and returning a safe default.

## Evidence

- **File references**: 
  - `src/barbossa/agents/discovery.py:109-113` - No try/except around `json.load(f)`
  - `src/barbossa/agents/product.py:106-110` - No try/except around `json.load(f)`
  - `src/barbossa/agents/spec_generator.py:110-114` - No try/except around `json.load(f)`
  - `src/barbossa/agents/tech_lead.py:147-153` - No try/except around `json.load(f)`
  - `src/barbossa/agents/auditor.py:105-111` - No try/except around `json.load(f)`
  - `src/barbossa/agents/engineer.py:112-119` - No try/except around `json.load(f)`
- **Issue**: Config validation improvements is listed as a priority area in KNOWN GAPS

## Dependencies

- Lockfile changes: NO
- Dependency changes: NONE

## Changes

- `auditor.py`: Add JSONDecodeError handling in `_load_config()`
- `discovery.py`: Add JSONDecodeError handling in `_load_config()`
- `engineer.py`: Add JSONDecodeError handling in `_load_config()`
- `product.py`: Add JSONDecodeError handling in `_load_config()`
- `spec_generator.py`: Add JSONDecodeError handling in `_load_config()`
- `tech_lead.py`: Add JSONDecodeError handling in `_load_config()`
- `tests/test_config_loading.py`: Add tests for invalid and valid JSON handling

## Testing

- All new tests pass (`pytest tests/test_config_loading.py -v`)
- Tests verify that:
  1. Invalid JSON logs an error message containing "Invalid JSON"
  2. Invalid JSON results in clean ValueError (owner required) instead of JSONDecodeError
  3. Valid JSON still loads correctly without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)