### PR TITLE
feat: add webhook notification retry queue with exponential backoff

### DIFF
--- a/src/barbossa/agents/auditor.py
+++ b/src/barbossa/agents/auditor.py
@@ -38,7 +38,8 @@ from barbossa.utils.issue_tracker import get_issue_tracker, IssueTracker
 from barbossa.utils.notifications import (
     notify_agent_run_complete,
     notify_error,
-    wait_for_pending
+    wait_for_pending,
+    process_retry_queue
 )
 
 
@@ -1770,6 +1771,9 @@ class BarbossaAuditor:
         self.logger.info(f"Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
         self.logger.info(f"Analysis Period: Last {days} days")
         self.logger.info(f"{'#'*70}\n")
+
+        # Process any pending webhook retries from previous runs
+        process_retry_queue()
 
         # Track run start (fire-and-forget, never blocks)
         track_run_start("auditor", run_session_id, len(self.repositories))

--- a/src/barbossa/agents/discovery.py
+++ b/src/barbossa/agents/discovery.py
@@ -40,7 +40,8 @@ from barbossa.utils.issue_tracker import get_issue_tracker, IssueTracker
 from barbossa.utils.notifications import (
     notify_agent_run_complete,
     notify_error,
-    wait_for_pending
+    wait_for_pending,
+    process_retry_queue
 )
 
 
@@ -543,6 +544,9 @@ Found console.log statements in production code that should be removed.
         self.logger.info("BARBOSSA DISCOVERY RUN")
         self.logger.info(f"Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
         self.logger.info(f"{'#'*60}\n")
+
+        # Process any pending webhook retries from previous runs
+        process_retry_queue()
 
         # Track run start (fire-and-forget, never blocks)
         track_run_start("discovery", run_session_id, len(self.repositories))

--- a/src/barbossa/agents/engineer.py
+++ b/src/barbossa/agents/engineer.py
@@ -37,7 +37,8 @@ from barbossa.utils.notifications import (
     notify_agent_run_complete,
     notify_pr_created,
     notify_error,
-    wait_for_pending
+    wait_for_pending,
+    process_retry_queue
 )
 
 
@@ -1017,6 +1018,9 @@ Begin your work now."""
         self.logger.info(f"BARBOSSA RUN STARTED")
         self.logger.info(f"Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
         self.logger.info(f"{'#'*60}\n")
+
+        # Process any pending webhook retries from previous runs
+        process_retry_queue()
 
         # Track run start (fire-and-forget, never blocks)
         track_run_start("engineer", run_session_id, len(self.repositories))

--- a/src/barbossa/agents/product.py
+++ b/src/barbossa/agents/product.py
@@ -41,7 +41,8 @@ from barbossa.utils.issue_tracker import get_issue_tracker, IssueTracker
 from barbossa.utils.notifications import (
     notify_agent_run_complete,
     notify_error,
-    wait_for_pending
+    wait_for_pending,
+    process_retry_queue
 )
 
 
@@ -602,6 +603,9 @@ KEY FILES:
         self.logger.info("BARBOSSA PRODUCT MANAGER RUN")
         self.logger.info(f"Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
         self.logger.info(f"{'#'*60}\n")
+
+        # Process any pending webhook retries from previous runs
+        process_retry_queue()
 
         # Track run start (fire-and-forget, never blocks)
         track_run_start("product_manager", run_session_id, len(self.repositories))

--- a/src/barbossa/agents/spec_generator.py
+++ b/src/barbossa/agents/spec_generator.py
@@ -31,7 +31,8 @@ from barbossa.utils.notifications import (
     notify_agent_run_complete,
     notify_error,
     notify_spec_created,
-    wait_for_pending
+    wait_for_pending,
+    process_retry_queue
 )
 
 
@@ -852,6 +853,9 @@ This ticket covers the **{repo_name}** portion of: **{spec.get('title', 'Feature
         self.logger.info("BARBOSSA SPEC GENERATOR RUN")
         self.logger.info(f"Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
         self.logger.info(f"{'#'*60}\n")
+
+        # Process any pending webhook retries from previous runs
+        process_retry_queue()
 
         # Track run start
         track_run_start("spec_generator", run_session_id, len(self.products))

--- a/src/barbossa/agents/tech_lead.py
+++ b/src/barbossa/agents/tech_lead.py
@@ -38,7 +38,8 @@ from barbossa.utils.notifications import (
     notify_pr_merged,
     notify_pr_closed,
     notify_error,
-    wait_for_pending
+    wait_for_pending,
+    process_retry_queue
 )
 
 
@@ -1219,6 +1220,9 @@ _Senior Engineer: Please address the above feedback and push updates._"""
         self.logger.info("Mode: GitHub as single source of truth (no file-based state)")
         self.logger.info(f"Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
         self.logger.info(f"{'#'*70}\n")
+
+        # Process any pending webhook retries from previous runs
+        process_retry_queue()
 
         # Track run start (fire-and-forget, never blocks)
         track_run_start("tech_lead", run_session_id, len(self.repositories))

--- a/src/barbossa/utils/notifications.py
+++ b/src/barbossa/utils/notifications.py
@@ -32,14 +32,15 @@ import json
 import logging
 import os
 import threading
-from datetime import datetime
+import time
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 
 # Current version
-VERSION = "1.8.0"
+VERSION = "1.8.1"
 
 # Timeout for webhook calls (short - we never want to block)
 WEBHOOK_TIMEOUT = 10
@@ -53,6 +54,211 @@ _config_loaded = False
 # Track pending notification threads so we can wait for them before process exit
 _pending_threads: List[threading.Thread] = []
 _threads_lock = threading.Lock()
+
+# =============================================================================
+# RETRY QUEUE IMPLEMENTATION
+# =============================================================================
+# Failed webhooks are queued for retry with exponential backoff.
+# Queue is persisted to disk so retries survive process restarts.
+
+# Retry configuration
+MAX_RETRIES = 3
+BASE_DELAY_SECONDS = 60  # 1 minute base delay
+MAX_RETENTION_HOURS = 24  # Drop queued items after 24 hours
+
+# Queue state
+_retry_queue_path: Optional[Path] = None
+_retry_queue_lock = threading.Lock()
+
+
+def _get_retry_queue_path() -> Path:
+    """Get the path to the retry queue file."""
+    global _retry_queue_path
+    if _retry_queue_path is not None:
+        return _retry_queue_path
+
+    # Use same config directory as repositories.json
+    data_dir = Path(os.environ.get('BARBOSSA_DIR', '/app')) / 'data'
+    data_dir.mkdir(parents=True, exist_ok=True)
+    _retry_queue_path = data_dir / 'webhook_retry_queue.json'
+    return _retry_queue_path
+
+
+def _load_retry_queue() -> List[Dict]:
+    """Load the retry queue from disk."""
+    queue_path = _get_retry_queue_path()
+    if not queue_path.exists():
+        return []
+
+    try:
+        with open(queue_path, 'r') as f:
+            queue = json.load(f)
+            if not isinstance(queue, list):
+                logger.warning("Invalid retry queue format, resetting")
+                return []
+            return queue
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning(f"Failed to load retry queue: {e}")
+        return []
+
+
+def _save_retry_queue(queue: List[Dict]) -> bool:
+    """Save the retry queue to disk."""
+    queue_path = _get_retry_queue_path()
+    try:
+        # Atomic write using temp file
+        temp_path = queue_path.with_suffix('.tmp')
+        with open(temp_path, 'w') as f:
+            json.dump(queue, f, indent=2)
+        temp_path.replace(queue_path)
+        return True
+    except IOError as e:
+        logger.warning(f"Failed to save retry queue: {e}")
+        return False
+
+
+def _queue_for_retry(payload: Dict, attempt: int = 1) -> bool:
+    """
+    Add a failed webhook payload to the retry queue.
+
+    Args:
+        payload: The webhook payload that failed
+        attempt: Current attempt number (1 = first failure)
+
+    Returns:
+        True if queued successfully
+    """
+    if attempt > MAX_RETRIES:
+        logger.warning(f"Webhook exhausted {MAX_RETRIES} retries, dropping")
+        return False
+
+    # Calculate next retry time with exponential backoff
+    delay_seconds = BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+    next_retry = datetime.utcnow() + timedelta(seconds=delay_seconds)
+
+    queue_entry = {
+        'payload': payload,
+        'attempt': attempt,
+        'created_at': datetime.utcnow().isoformat() + 'Z',
+        'next_retry_at': next_retry.isoformat() + 'Z',
+    }
+
+    with _retry_queue_lock:
+        queue = _load_retry_queue()
+        queue.append(queue_entry)
+
+        # Prune expired entries
+        cutoff = datetime.utcnow() - timedelta(hours=MAX_RETENTION_HOURS)
+        queue = [
+            entry for entry in queue
+            if datetime.fromisoformat(entry['created_at'].rstrip('Z')) > cutoff
+        ]
+
+        _save_retry_queue(queue)
+
+    logger.info(f"Queued webhook for retry (attempt {attempt + 1}) in {delay_seconds}s")
+    return True
+
+
+def process_retry_queue() -> Dict[str, int]:
+    """
+    Process any pending webhook retries.
+
+    This should be called at the start of agent runs to flush
+    any webhooks that failed on previous runs.
+
+    Returns:
+        Dict with 'processed', 'succeeded', 'failed', 'requeued' counts
+    """
+    stats = {'processed': 0, 'succeeded': 0, 'failed': 0, 'requeued': 0, 'expired': 0}
+
+    with _retry_queue_lock:
+        queue = _load_retry_queue()
+        if not queue:
+            return stats
+
+        now = datetime.utcnow()
+        remaining = []
+        to_process = []
+
+        # Separate items ready to retry from those still waiting
+        for entry in queue:
+            created_at = datetime.fromisoformat(entry['created_at'].rstrip('Z'))
+            next_retry = datetime.fromisoformat(entry['next_retry_at'].rstrip('Z'))
+
+            # Check if expired (older than MAX_RETENTION_HOURS)
+            if created_at < now - timedelta(hours=MAX_RETENTION_HOURS):
+                stats['expired'] += 1
+                continue
+
+            # Check if ready for retry
+            if next_retry <= now:
+                to_process.append(entry)
+            else:
+                remaining.append(entry)
+
+        # Update queue immediately with items not being processed
+        _save_retry_queue(remaining)
+
+    # Process outside the lock to avoid blocking
+    for entry in to_process:
+        stats['processed'] += 1
+        payload = entry['payload']
+        attempt = entry['attempt']
+
+        success = _send_discord_webhook_sync(payload)
+
+        if success:
+            stats['succeeded'] += 1
+            logger.info(f"Retry succeeded on attempt {attempt + 1}")
+        else:
+            # Queue for another retry if attempts remain
+            if attempt < MAX_RETRIES:
+                _queue_for_retry(payload, attempt + 1)
+                stats['requeued'] += 1
+            else:
+                stats['failed'] += 1
+                logger.warning(f"Webhook failed after {MAX_RETRIES + 1} attempts")
+
+    if stats['processed'] > 0:
+        logger.info(
+            f"Retry queue: {stats['processed']} processed, "
+            f"{stats['succeeded']} succeeded, {stats['requeued']} requeued, "
+            f"{stats['failed']} failed, {stats['expired']} expired"
+        )
+
+    return stats
+
+
+def get_retry_queue_status() -> Dict[str, Any]:
+    """
+    Get the current status of the retry queue.
+
+    Returns:
+        Dict with queue size, oldest entry age, next retry time, etc.
+    """
+    with _retry_queue_lock:
+        queue = _load_retry_queue()
+
+    if not queue:
+        return {'size': 0, 'oldest_age_minutes': 0, 'next_retry_in_seconds': None}
+
+    now = datetime.utcnow()
+    ages = []
+    next_retries = []
+
+    for entry in queue:
+        created_at = datetime.fromisoformat(entry['created_at'].rstrip('Z'))
+        next_retry = datetime.fromisoformat(entry['next_retry_at'].rstrip('Z'))
+        ages.append((now - created_at).total_seconds() / 60)
+        if next_retry > now:
+            next_retries.append((next_retry - now).total_seconds())
+
+    return {
+        'size': len(queue),
+        'oldest_age_minutes': max(ages) if ages else 0,
+        'next_retry_in_seconds': min(next_retries) if next_retries else None,
+    }
 
 
 def _load_notification_config() -> Dict:
@@ -187,12 +393,15 @@ AGENT_STYLES = {
 }
 
 
-def _send_discord_webhook(payload: Dict) -> bool:
+def _send_discord_webhook_sync(payload: Dict) -> bool:
     """
-    Send a payload to Discord webhook.
+    Send a payload to Discord webhook synchronously.
 
     NEVER raises exceptions - all errors are logged and swallowed.
     This ensures webhook issues never break agent execution.
+
+    Returns:
+        True if sent successfully, False otherwise
     """
     webhook_url = _get_discord_webhook()
     if not webhook_url:
@@ -228,6 +437,30 @@ def _send_discord_webhook(payload: Dict) -> bool:
     except Exception as e:
         logger.warning(f"Discord webhook error: {e}")
         return False
+
+
+def _send_discord_webhook(payload: Dict, queue_on_failure: bool = True) -> bool:
+    """
+    Send a payload to Discord webhook, queueing for retry on failure.
+
+    NEVER raises exceptions - all errors are logged and swallowed.
+    This ensures webhook issues never break agent execution.
+
+    Args:
+        payload: The webhook payload to send
+        queue_on_failure: If True, queue failed webhooks for retry
+
+    Returns:
+        True if sent successfully (or queued), False otherwise
+    """
+    success = _send_discord_webhook_sync(payload)
+
+    if not success and queue_on_failure:
+        # Queue for retry - return True since we've handled the failure
+        _queue_for_retry(payload, attempt=1)
+        return True  # Queued counts as handled
+
+    return success
 
 
 def _build_discord_embed(
@@ -664,6 +897,21 @@ if __name__ == "__main__":
     print(f"Enabled: {_is_enabled()}")
     print(f"Discord webhook: {'configured' if _get_discord_webhook() else 'not configured'}")
 
-    if len(sys.argv) > 1 and sys.argv[1] == 'test':
-        print("\nSending test notification...")
-        test_webhook()
+    # Show retry queue status
+    queue_status = get_retry_queue_status()
+    print(f"Retry queue size: {queue_status['size']}")
+    if queue_status['size'] > 0:
+        print(f"  Oldest entry: {queue_status['oldest_age_minutes']:.1f} minutes")
+        if queue_status['next_retry_in_seconds']:
+            print(f"  Next retry in: {queue_status['next_retry_in_seconds']:.0f} seconds")
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] == 'test':
+            print("\nSending test notification...")
+            test_webhook()
+        elif sys.argv[1] == 'retry':
+            print("\nProcessing retry queue...")
+            stats = process_retry_queue()
+            print(f"Processed: {stats['processed']}, Succeeded: {stats['succeeded']}, "
+                  f"Requeued: {stats['requeued']}, Failed: {stats['failed']}, "
+                  f"Expired: {stats['expired']}")

--- a/tests/test_notification_retry.py
+++ b/tests/test_notification_retry.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Tests for the webhook notification retry queue functionality.
+
+Covers:
+- Queue persistence (save/load)
+- Retry timing with exponential backoff
+- Expired entry cleanup
+- Queue status reporting
+- Webhook failure queueing
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch, Mock, MagicMock
+
+# Add src directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+from barbossa.utils.notifications import (
+    _load_retry_queue,
+    _save_retry_queue,
+    _queue_for_retry,
+    _get_retry_queue_path,
+    process_retry_queue,
+    get_retry_queue_status,
+    _send_discord_webhook,
+    _send_discord_webhook_sync,
+    MAX_RETRIES,
+    BASE_DELAY_SECONDS,
+    MAX_RETENTION_HOURS,
+)
+
+
+class TestRetryQueuePersistence(unittest.TestCase):
+    """Test queue save/load functionality."""
+
+    def setUp(self):
+        """Create a temporary directory for queue files."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.data_dir = self.temp_dir / 'data'
+        self.data_dir.mkdir()
+
+        # Patch the queue path to use our temp directory
+        import barbossa.utils.notifications as notif
+        self._original_path = notif._retry_queue_path
+        notif._retry_queue_path = self.data_dir / 'webhook_retry_queue.json'
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        import barbossa.utils.notifications as notif
+        notif._retry_queue_path = self._original_path
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_load_empty_queue(self):
+        """Loading a non-existent queue returns empty list."""
+        queue = _load_retry_queue()
+        self.assertEqual(queue, [])
+
+    def test_save_and_load_queue(self):
+        """Queue entries can be saved and loaded."""
+        test_entry = {
+            'payload': {'embeds': [{'title': 'Test'}]},
+            'attempt': 1,
+            'created_at': '2026-01-03T12:00:00Z',
+            'next_retry_at': '2026-01-03T12:01:00Z',
+        }
+
+        # Save
+        result = _save_retry_queue([test_entry])
+        self.assertTrue(result)
+
+        # Load
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0]['payload'], test_entry['payload'])
+        self.assertEqual(queue[0]['attempt'], 1)
+
+    def test_load_invalid_json(self):
+        """Loading invalid JSON returns empty list."""
+        import barbossa.utils.notifications as notif
+        queue_path = notif._retry_queue_path
+        queue_path.write_text('{ invalid json }')
+
+        queue = _load_retry_queue()
+        self.assertEqual(queue, [])
+
+    def test_load_non_list_returns_empty(self):
+        """Loading non-list JSON returns empty list."""
+        import barbossa.utils.notifications as notif
+        queue_path = notif._retry_queue_path
+        queue_path.write_text('{"not": "a list"}')
+
+        queue = _load_retry_queue()
+        self.assertEqual(queue, [])
+
+
+class TestQueueForRetry(unittest.TestCase):
+    """Test the _queue_for_retry function."""
+
+    def setUp(self):
+        """Create temp directory for tests."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.data_dir = self.temp_dir / 'data'
+        self.data_dir.mkdir()
+
+        import barbossa.utils.notifications as notif
+        self._original_path = notif._retry_queue_path
+        notif._retry_queue_path = self.data_dir / 'webhook_retry_queue.json'
+
+    def tearDown(self):
+        """Clean up."""
+        import barbossa.utils.notifications as notif
+        notif._retry_queue_path = self._original_path
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_queue_first_retry(self):
+        """First retry is queued with attempt=1."""
+        payload = {'embeds': [{'title': 'Test Notification'}]}
+
+        result = _queue_for_retry(payload, attempt=1)
+        self.assertTrue(result)
+
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0]['attempt'], 1)
+        self.assertEqual(queue[0]['payload'], payload)
+
+    def test_exponential_backoff(self):
+        """Retry delays increase exponentially."""
+        payload = {'embeds': [{'title': 'Test'}]}
+
+        # First retry: 60s delay
+        _queue_for_retry(payload, attempt=1)
+        queue = _load_retry_queue()
+        created = datetime.fromisoformat(queue[0]['created_at'].rstrip('Z'))
+        next_retry = datetime.fromisoformat(queue[0]['next_retry_at'].rstrip('Z'))
+        delay1 = (next_retry - created).total_seconds()
+        self.assertAlmostEqual(delay1, BASE_DELAY_SECONDS, delta=1)
+
+        # Clear and test second retry: 120s delay
+        _save_retry_queue([])
+        _queue_for_retry(payload, attempt=2)
+        queue = _load_retry_queue()
+        created = datetime.fromisoformat(queue[0]['created_at'].rstrip('Z'))
+        next_retry = datetime.fromisoformat(queue[0]['next_retry_at'].rstrip('Z'))
+        delay2 = (next_retry - created).total_seconds()
+        self.assertAlmostEqual(delay2, BASE_DELAY_SECONDS * 2, delta=1)
+
+        # Clear and test third retry: 240s delay
+        _save_retry_queue([])
+        _queue_for_retry(payload, attempt=3)
+        queue = _load_retry_queue()
+        created = datetime.fromisoformat(queue[0]['created_at'].rstrip('Z'))
+        next_retry = datetime.fromisoformat(queue[0]['next_retry_at'].rstrip('Z'))
+        delay3 = (next_retry - created).total_seconds()
+        self.assertAlmostEqual(delay3, BASE_DELAY_SECONDS * 4, delta=1)
+
+    def test_max_retries_exceeded(self):
+        """Queueing beyond MAX_RETRIES returns False."""
+        payload = {'embeds': [{'title': 'Test'}]}
+
+        result = _queue_for_retry(payload, attempt=MAX_RETRIES + 1)
+        self.assertFalse(result)
+
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 0)
+
+    def test_expired_entries_pruned(self):
+        """Expired entries are removed when adding new ones."""
+        import barbossa.utils.notifications as notif
+
+        # Add an expired entry manually
+        old_time = (datetime.utcnow() - timedelta(hours=MAX_RETENTION_HOURS + 1)).isoformat() + 'Z'
+        expired_entry = {
+            'payload': {'embeds': [{'title': 'Old'}]},
+            'attempt': 1,
+            'created_at': old_time,
+            'next_retry_at': old_time,
+        }
+        _save_retry_queue([expired_entry])
+
+        # Add a new entry
+        _queue_for_retry({'embeds': [{'title': 'New'}]}, attempt=1)
+
+        # Only the new entry should remain
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0]['payload']['embeds'][0]['title'], 'New')
+
+
+class TestProcessRetryQueue(unittest.TestCase):
+    """Test the process_retry_queue function."""
+
+    def setUp(self):
+        """Create temp directory for tests."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.data_dir = self.temp_dir / 'data'
+        self.data_dir.mkdir()
+
+        import barbossa.utils.notifications as notif
+        self._original_path = notif._retry_queue_path
+        notif._retry_queue_path = self.data_dir / 'webhook_retry_queue.json'
+
+    def tearDown(self):
+        """Clean up."""
+        import barbossa.utils.notifications as notif
+        notif._retry_queue_path = self._original_path
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_empty_queue_returns_zero_stats(self):
+        """Processing empty queue returns zero stats."""
+        stats = process_retry_queue()
+        self.assertEqual(stats['processed'], 0)
+        self.assertEqual(stats['succeeded'], 0)
+
+    @patch('barbossa.utils.notifications._send_discord_webhook_sync')
+    def test_successful_retry(self, mock_send):
+        """Successful retry removes entry from queue."""
+        mock_send.return_value = True
+
+        # Add a ready-to-retry entry
+        past_time = (datetime.utcnow() - timedelta(seconds=1)).isoformat() + 'Z'
+        entry = {
+            'payload': {'embeds': [{'title': 'Test'}]},
+            'attempt': 1,
+            'created_at': past_time,
+            'next_retry_at': past_time,
+        }
+        _save_retry_queue([entry])
+
+        stats = process_retry_queue()
+
+        self.assertEqual(stats['processed'], 1)
+        self.assertEqual(stats['succeeded'], 1)
+        self.assertEqual(stats['requeued'], 0)
+
+        # Queue should be empty
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 0)
+
+    @patch('barbossa.utils.notifications._send_discord_webhook_sync')
+    def test_failed_retry_requeues(self, mock_send):
+        """Failed retry requeues with incremented attempt."""
+        mock_send.return_value = False
+
+        past_time = (datetime.utcnow() - timedelta(seconds=1)).isoformat() + 'Z'
+        entry = {
+            'payload': {'embeds': [{'title': 'Test'}]},
+            'attempt': 1,
+            'created_at': past_time,
+            'next_retry_at': past_time,
+        }
+        _save_retry_queue([entry])
+
+        stats = process_retry_queue()
+
+        self.assertEqual(stats['processed'], 1)
+        self.assertEqual(stats['succeeded'], 0)
+        self.assertEqual(stats['requeued'], 1)
+
+        # Entry should be requeued with attempt=2
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0]['attempt'], 2)
+
+    @patch('barbossa.utils.notifications._send_discord_webhook_sync')
+    def test_max_retries_drops_entry(self, mock_send):
+        """Entry at MAX_RETRIES that fails is dropped."""
+        mock_send.return_value = False
+
+        past_time = (datetime.utcnow() - timedelta(seconds=1)).isoformat() + 'Z'
+        entry = {
+            'payload': {'embeds': [{'title': 'Test'}]},
+            'attempt': MAX_RETRIES,
+            'created_at': past_time,
+            'next_retry_at': past_time,
+        }
+        _save_retry_queue([entry])
+
+        stats = process_retry_queue()
+
+        self.assertEqual(stats['processed'], 1)
+        self.assertEqual(stats['failed'], 1)
+        self.assertEqual(stats['requeued'], 0)
+
+        # Queue should be empty
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 0)
+
+    def test_future_entries_not_processed(self):
+        """Entries with future next_retry_at are not processed."""
+        future_time = (datetime.utcnow() + timedelta(hours=1)).isoformat() + 'Z'
+        now = datetime.utcnow().isoformat() + 'Z'
+        entry = {
+            'payload': {'embeds': [{'title': 'Test'}]},
+            'attempt': 1,
+            'created_at': now,
+            'next_retry_at': future_time,
+        }
+        _save_retry_queue([entry])
+
+        stats = process_retry_queue()
+
+        self.assertEqual(stats['processed'], 0)
+
+        # Entry should still be in queue
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 1)
+
+    def test_expired_entries_counted(self):
+        """Expired entries are counted and removed."""
+        old_time = (datetime.utcnow() - timedelta(hours=MAX_RETENTION_HOURS + 1)).isoformat() + 'Z'
+        entry = {
+            'payload': {'embeds': [{'title': 'Old'}]},
+            'attempt': 1,
+            'created_at': old_time,
+            'next_retry_at': old_time,
+        }
+        _save_retry_queue([entry])
+
+        stats = process_retry_queue()
+
+        self.assertEqual(stats['expired'], 1)
+        self.assertEqual(stats['processed'], 0)
+
+
+class TestGetRetryQueueStatus(unittest.TestCase):
+    """Test the get_retry_queue_status function."""
+
+    def setUp(self):
+        """Create temp directory for tests."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.data_dir = self.temp_dir / 'data'
+        self.data_dir.mkdir()
+
+        import barbossa.utils.notifications as notif
+        self._original_path = notif._retry_queue_path
+        notif._retry_queue_path = self.data_dir / 'webhook_retry_queue.json'
+
+    def tearDown(self):
+        """Clean up."""
+        import barbossa.utils.notifications as notif
+        notif._retry_queue_path = self._original_path
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_empty_queue_status(self):
+        """Empty queue returns zero values."""
+        status = get_retry_queue_status()
+        self.assertEqual(status['size'], 0)
+        self.assertEqual(status['oldest_age_minutes'], 0)
+        self.assertIsNone(status['next_retry_in_seconds'])
+
+    def test_queue_with_entries(self):
+        """Queue with entries returns correct stats."""
+        now = datetime.utcnow()
+        old_time = (now - timedelta(minutes=30)).isoformat() + 'Z'
+        future_time = (now + timedelta(seconds=120)).isoformat() + 'Z'
+
+        entries = [
+            {
+                'payload': {'embeds': [{'title': 'Old'}]},
+                'attempt': 1,
+                'created_at': old_time,
+                'next_retry_at': future_time,
+            },
+            {
+                'payload': {'embeds': [{'title': 'New'}]},
+                'attempt': 1,
+                'created_at': now.isoformat() + 'Z',
+                'next_retry_at': future_time,
+            },
+        ]
+        _save_retry_queue(entries)
+
+        status = get_retry_queue_status()
+
+        self.assertEqual(status['size'], 2)
+        self.assertAlmostEqual(status['oldest_age_minutes'], 30, delta=1)
+        self.assertIsNotNone(status['next_retry_in_seconds'])
+        self.assertGreater(status['next_retry_in_seconds'], 0)
+
+
+class TestWebhookQueueingOnFailure(unittest.TestCase):
+    """Test that webhook failures are queued for retry."""
+
+    def setUp(self):
+        """Create temp directory for tests."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.data_dir = self.temp_dir / 'data'
+        self.data_dir.mkdir()
+
+        import barbossa.utils.notifications as notif
+        self._original_path = notif._retry_queue_path
+        notif._retry_queue_path = self.data_dir / 'webhook_retry_queue.json'
+
+    def tearDown(self):
+        """Clean up."""
+        import barbossa.utils.notifications as notif
+        notif._retry_queue_path = self._original_path
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('barbossa.utils.notifications._send_discord_webhook_sync')
+    @patch('barbossa.utils.notifications._get_discord_webhook')
+    def test_failed_webhook_queued(self, mock_get_webhook, mock_sync_send):
+        """Failed webhook is queued for retry."""
+        mock_get_webhook.return_value = 'https://discord.com/api/webhooks/test'
+        mock_sync_send.return_value = False
+
+        payload = {'embeds': [{'title': 'Test'}]}
+        result = _send_discord_webhook(payload, queue_on_failure=True)
+
+        # Should return True because failure was handled by queueing
+        self.assertTrue(result)
+
+        # Should be in queue
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 1)
+
+    @patch('barbossa.utils.notifications._send_discord_webhook_sync')
+    @patch('barbossa.utils.notifications._get_discord_webhook')
+    def test_successful_webhook_not_queued(self, mock_get_webhook, mock_sync_send):
+        """Successful webhook is not queued."""
+        mock_get_webhook.return_value = 'https://discord.com/api/webhooks/test'
+        mock_sync_send.return_value = True
+
+        payload = {'embeds': [{'title': 'Test'}]}
+        result = _send_discord_webhook(payload, queue_on_failure=True)
+
+        self.assertTrue(result)
+
+        # Should NOT be in queue
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 0)
+
+    @patch('barbossa.utils.notifications._send_discord_webhook_sync')
+    @patch('barbossa.utils.notifications._get_discord_webhook')
+    def test_queue_disabled(self, mock_get_webhook, mock_sync_send):
+        """When queue_on_failure=False, failures are not queued."""
+        mock_get_webhook.return_value = 'https://discord.com/api/webhooks/test'
+        mock_sync_send.return_value = False
+
+        payload = {'embeds': [{'title': 'Test'}]}
+        result = _send_discord_webhook(payload, queue_on_failure=False)
+
+        self.assertFalse(result)
+
+        # Should NOT be in queue
+        queue = _load_retry_queue()
+        self.assertEqual(len(queue), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implements a persistent retry queue for failed Discord webhook notifications
- Addresses the "Notification webhook retry logic" gap from KNOWN GAPS in system reliability
- Failed webhooks are automatically queued for retry with exponential backoff

## Evidence
- Linked issue: #11 (Agent timeout handling and retry/checkpoint framework)
- KNOWN GAPS explicitly mentions: "Notification webhook retry logic"
- Current behavior: Failed webhooks are fire-and-forget with no retry (see `notifications.py:190-231`)

## Dependencies
- Lockfile changes: NO
- Dependency changes: NONE (uses stdlib only: json, datetime, threading, pathlib)

## Changes
- **notifications.py**: 
  - Add retry queue with file-based persistence (`data/webhook_retry_queue.json`)
  - Implement exponential backoff: 60s → 120s → 240s delays
  - Queue failed webhooks automatically (up to 3 retries, 24h retention)
  - Add `process_retry_queue()` to flush pending retries
  - Add `get_retry_queue_status()` for monitoring
  - Add CLI support: `python notifications.py retry`

- **All 6 agents** (engineer, tech_lead, auditor, discovery, product, spec_generator):
  - Call `process_retry_queue()` at run start to process pending notifications

- **tests/test_notification_retry.py**: 
  - 19 comprehensive unit tests covering queue persistence, exponential backoff, expiration, and retry logic

## Testing
- Ran 28 tests including 19 new retry queue tests: all pass
- Verified all agent imports work correctly
- Tested queue status reporting

Closes #11 (partial - webhook retry portion of the larger issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)