### PR TITLE
fix: handle missing/invalid OAuth expiration timestamp in auditor

### DIFF
--- a/src/barbossa/agents/auditor.py
+++ b/src/barbossa/agents/auditor.py
@@ -1294,7 +1294,18 @@ class BarbossaAuditor:
                 creds = json.load(f)
 
             oauth = creds.get('claudeAiOauth', {})
-            expires_at = oauth.get('expiresAt', 0)
+            if not oauth:
+                result['status'] = 'error'
+                result['message'] = 'No claudeAiOauth data in credentials file'
+                self.logger.warning("⚠️ Credentials file exists but has no claudeAiOauth data")
+                return result
+
+            expires_at = oauth.get('expiresAt')
+            if expires_at is None or expires_at == 0:
+                result['status'] = 'error'
+                result['message'] = 'OAuth token has no expiration timestamp'
+                self.logger.warning("⚠️ OAuth token missing expiresAt field")
+                return result
 
             # Convert ms to seconds
             expires_ts = expires_at / 1000 if expires_at > 1e12 else expires_at

--- a/tests/test_oauth_token_edge_cases.py
+++ b/tests/test_oauth_token_edge_cases.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Tests for OAuth token edge case handling in the Auditor agent.
+
+Verifies that _check_oauth_token() handles missing or malformed
+credential data gracefully instead of producing misleading results.
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add src directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+
+class TestOAuthTokenEdgeCases(unittest.TestCase):
+    """Test OAuth token checking edge cases."""
+
+    def setUp(self):
+        """Create temp directory structure for auditor."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.config_dir = self.temp_dir / 'config'
+        self.config_dir.mkdir()
+        self.logs_dir = self.temp_dir / 'logs'
+        self.logs_dir.mkdir()
+        self.claude_dir = self.temp_dir / '.claude'
+        self.claude_dir.mkdir()
+        self.creds_file = self.claude_dir / '.credentials.json'
+
+        # Valid config for auditor initialization
+        self.config_path = self.config_dir / 'repositories.json'
+        self.config_path.write_text(json.dumps({
+            'owner': 'test-owner',
+            'repositories': [{'name': 'test-repo', 'url': 'https://github.com/test/test'}]
+        }))
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('barbossa.agents.auditor.logging')
+    @patch('barbossa.agents.auditor.get_client')
+    @patch('barbossa.agents.auditor.check_version')
+    def test_missing_claudeAiOauth_key(self, mock_check_version, mock_get_client, mock_logging):
+        """When claudeAiOauth key is missing, should return error status."""
+        from barbossa.agents.auditor import BarbossaAuditor
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+        mock_check_version.return_value = None
+        mock_get_client.return_value = None
+
+        # Write credentials file without claudeAiOauth
+        self.creds_file.write_text(json.dumps({'someOtherKey': 'value'}))
+
+        auditor = BarbossaAuditor(work_dir=self.temp_dir)
+
+        # Patch Path.home() to return our temp dir for the credential check
+        with patch.object(Path, 'home', return_value=self.temp_dir):
+            result = auditor._check_oauth_token()
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('No claudeAiOauth data', result['message'])
+
+    @patch('barbossa.agents.auditor.logging')
+    @patch('barbossa.agents.auditor.get_client')
+    @patch('barbossa.agents.auditor.check_version')
+    def test_empty_claudeAiOauth_object(self, mock_check_version, mock_get_client, mock_logging):
+        """When claudeAiOauth is an empty object, should return error status."""
+        from barbossa.agents.auditor import BarbossaAuditor
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+        mock_check_version.return_value = None
+        mock_get_client.return_value = None
+
+        # Write credentials file with empty claudeAiOauth
+        self.creds_file.write_text(json.dumps({'claudeAiOauth': {}}))
+
+        auditor = BarbossaAuditor(work_dir=self.temp_dir)
+
+        with patch.object(Path, 'home', return_value=self.temp_dir):
+            result = auditor._check_oauth_token()
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('No claudeAiOauth data', result['message'])
+
+    @patch('barbossa.agents.auditor.logging')
+    @patch('barbossa.agents.auditor.get_client')
+    @patch('barbossa.agents.auditor.check_version')
+    def test_missing_expiresAt_field(self, mock_check_version, mock_get_client, mock_logging):
+        """When expiresAt field is missing, should return error status."""
+        from barbossa.agents.auditor import BarbossaAuditor
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+        mock_check_version.return_value = None
+        mock_get_client.return_value = None
+
+        # Write credentials file with claudeAiOauth but no expiresAt
+        self.creds_file.write_text(json.dumps({
+            'claudeAiOauth': {'accessToken': 'some-token', 'refreshToken': 'some-refresh'}
+        }))
+
+        auditor = BarbossaAuditor(work_dir=self.temp_dir)
+
+        with patch.object(Path, 'home', return_value=self.temp_dir):
+            result = auditor._check_oauth_token()
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('no expiration timestamp', result['message'])
+
+    @patch('barbossa.agents.auditor.logging')
+    @patch('barbossa.agents.auditor.get_client')
+    @patch('barbossa.agents.auditor.check_version')
+    def test_expiresAt_is_zero(self, mock_check_version, mock_get_client, mock_logging):
+        """When expiresAt is 0, should return error status instead of epoch date."""
+        from barbossa.agents.auditor import BarbossaAuditor
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+        mock_check_version.return_value = None
+        mock_get_client.return_value = None
+
+        # Write credentials file with expiresAt = 0
+        self.creds_file.write_text(json.dumps({
+            'claudeAiOauth': {'accessToken': 'some-token', 'expiresAt': 0}
+        }))
+
+        auditor = BarbossaAuditor(work_dir=self.temp_dir)
+
+        with patch.object(Path, 'home', return_value=self.temp_dir):
+            result = auditor._check_oauth_token()
+
+        # Should return error, not claim token expired at 1970
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('no expiration timestamp', result['message'])
+        # Verify it doesn't contain epoch date
+        self.assertNotIn('1970', result['message'])
+
+    @patch('barbossa.agents.auditor.logging')
+    @patch('barbossa.agents.auditor.get_client')
+    @patch('barbossa.agents.auditor.check_version')
+    def test_valid_token_still_works(self, mock_check_version, mock_get_client, mock_logging):
+        """Valid token with proper expiresAt should still work correctly."""
+        from barbossa.agents.auditor import BarbossaAuditor
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+        mock_check_version.return_value = None
+        mock_get_client.return_value = None
+
+        # Write credentials file with valid future expiresAt (in milliseconds)
+        future_time = datetime.now() + timedelta(days=7)
+        expires_at_ms = int(future_time.timestamp() * 1000)
+        self.creds_file.write_text(json.dumps({
+            'claudeAiOauth': {'accessToken': 'some-token', 'expiresAt': expires_at_ms}
+        }))
+
+        auditor = BarbossaAuditor(work_dir=self.temp_dir)
+
+        with patch.object(Path, 'home', return_value=self.temp_dir):
+            result = auditor._check_oauth_token()
+
+        self.assertEqual(result['status'], 'ok')
+        self.assertIn('valid for', result['message'])
+
+    @patch('barbossa.agents.auditor.logging')
+    @patch('barbossa.agents.auditor.get_client')
+    @patch('barbossa.agents.auditor.check_version')
+    def test_expired_token_detected(self, mock_check_version, mock_get_client, mock_logging):
+        """Expired token should be correctly detected as expired."""
+        from barbossa.agents.auditor import BarbossaAuditor
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+        mock_check_version.return_value = None
+        mock_get_client.return_value = None
+
+        # Write credentials file with past expiresAt (in milliseconds)
+        past_time = datetime.now() - timedelta(hours=2)
+        expires_at_ms = int(past_time.timestamp() * 1000)
+        self.creds_file.write_text(json.dumps({
+            'claudeAiOauth': {'accessToken': 'some-token', 'expiresAt': expires_at_ms}
+        }))
+
+        auditor = BarbossaAuditor(work_dir=self.temp_dir)
+
+        with patch.object(Path, 'home', return_value=self.temp_dir):
+            result = auditor._check_oauth_token()
+
+        self.assertEqual(result['status'], 'expired')
+        self.assertIn('EXPIRED', result['message'])
+
+    @patch('barbossa.agents.auditor.logging')
+    @patch('barbossa.agents.auditor.get_client')
+    @patch('barbossa.agents.auditor.check_version')
+    def test_expiring_soon_warning(self, mock_check_version, mock_get_client, mock_logging):
+        """Token expiring within 24 hours should get warning status."""
+        from barbossa.agents.auditor import BarbossaAuditor
+
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        mock_logging.INFO = 20
+        mock_logging.FileHandler = MagicMock()
+        mock_logging.StreamHandler = MagicMock()
+        mock_check_version.return_value = None
+        mock_get_client.return_value = None
+
+        # Write credentials file with expiresAt in 12 hours (in milliseconds)
+        future_time = datetime.now() + timedelta(hours=12)
+        expires_at_ms = int(future_time.timestamp() * 1000)
+        self.creds_file.write_text(json.dumps({
+            'claudeAiOauth': {'accessToken': 'some-token', 'expiresAt': expires_at_ms}
+        }))
+
+        auditor = BarbossaAuditor(work_dir=self.temp_dir)
+
+        with patch.object(Path, 'home', return_value=self.temp_dir):
+            result = auditor._check_oauth_token()
+
+        self.assertEqual(result['status'], 'warning')
+        self.assertIn('expires in', result['message'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes edge case handling in the auditor's OAuth token checking logic that caused misleading error messages when credential data was missing or malformed.

## Evidence
- **File:** `src/barbossa/agents/auditor.py:1297-1301`
- **Issue:** When `expiresAt` is 0 or missing, `datetime.fromtimestamp(0)` returns the Unix epoch (1970-01-01), causing:
  - `hours_until_expiry` to be a large negative number
  - Token incorrectly reported as "EXPIRED at 1970-01-01 00:00:00"
  - Confusing error messages in logs

This can occur when:
- Credentials file exists but has no `claudeAiOauth` key
- `claudeAiOauth` object exists but has no `expiresAt` field
- Token was created but expiration wasn't properly set

## Dependencies
- Lockfile changes: NO
- Dependency changes: NONE

## Changes
- Added validation for missing `claudeAiOauth` key in credentials file
- Added validation for empty `claudeAiOauth` object
- Added explicit check for missing or zero `expiresAt` field
- Returns clear, actionable error messages instead of confusing epoch-date errors

## Testing
- Added 7 new unit tests covering all edge cases:
  - `test_missing_claudeAiOauth_key` - Missing key in credentials
  - `test_empty_claudeAiOauth_object` - Empty OAuth object
  - `test_missing_expiresAt_field` - Missing expiration field
  - `test_expiresAt_is_zero` - Zero expiration (the main bug)
  - `test_valid_token_still_works` - Regression test for valid tokens
  - `test_expired_token_detected` - Correctly detects expired tokens
  - `test_expiring_soon_warning` - Warning for tokens expiring soon

All tests pass:
```
Ran 7 tests in 0.057s
OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)