### PR TITLE
fix: enhance config validation with URL format, duplicate, and webhook checks

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """
-Tests for scripts/validate.py exception handling
+Tests for scripts/validate.py exception handling and config validation
 
-Ensures that bare except blocks have been replaced with specific exception types.
+Tests configuration validation including URL format, duplicate detection,
+and Discord webhook URL validation.
 """
 
+import json
 import subprocess
 import sys
+import tempfile
 import unittest
 from unittest.mock import patch, Mock
 from pathlib import Path
@@ -85,6 +88,274 @@ class TestNoBareExcepts(unittest.TestCase):
             bare_excepts, [],
             f"Found bare except blocks:\n" + "\n".join(bare_excepts)
         )
+
+
+class TestConfigValidation(unittest.TestCase):
+    """Test configuration validation functions"""
+
+    def setUp(self):
+        """Create a temporary config file for testing"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.config_path = Path(self.temp_dir) / 'repositories.json'
+
+    def tearDown(self):
+        """Clean up temporary files"""
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _write_config(self, config):
+        """Helper to write config JSON"""
+        with open(self.config_path, 'w') as f:
+            json.dump(config, f)
+
+    @patch('validate.Path')
+    def test_duplicate_repository_names_detected(self, mock_path):
+        """Test that duplicate repository names are detected"""
+        from validate import validate_config
+
+        config = {
+            "owner": "testuser",
+            "repositories": [
+                {"name": "my-app", "url": "https://github.com/testuser/my-app.git"},
+                {"name": "my-app", "url": "https://github.com/testuser/my-app-2.git"}
+            ]
+        }
+
+        # Mock Path to return our config
+        mock_path.return_value.exists.return_value = True
+        mock_path.return_value.__truediv__ = lambda self, x: self.config_path if 'repositories' in x else self
+
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_config()
+            self.assertFalse(result)
+
+    @patch('validate.Path')
+    def test_valid_github_https_url(self, mock_path):
+        """Test that valid GitHub HTTPS URLs pass validation"""
+        from validate import validate_config
+
+        config = {
+            "owner": "testuser",
+            "repositories": [
+                {"name": "my-app", "url": "https://github.com/testuser/my-app.git"}
+            ]
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_config()
+            self.assertTrue(result)
+
+    @patch('validate.Path')
+    def test_valid_github_ssh_url(self, mock_path):
+        """Test that valid GitHub SSH URLs pass validation"""
+        from validate import validate_config
+
+        config = {
+            "owner": "testuser",
+            "repositories": [
+                {"name": "my-app", "url": "git@github.com:testuser/my-app.git"}
+            ]
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_config()
+            self.assertTrue(result)
+
+    @patch('validate.Path')
+    def test_invalid_repository_url_rejected(self, mock_path):
+        """Test that invalid repository URLs are rejected"""
+        from validate import validate_config
+
+        config = {
+            "owner": "testuser",
+            "repositories": [
+                {"name": "my-app", "url": "http://example.com/repo.git"}
+            ]
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_config()
+            self.assertFalse(result)
+
+    @patch('validate.Path')
+    def test_gitlab_url_accepted(self, mock_path):
+        """Test that GitLab URLs are accepted"""
+        from validate import validate_config
+
+        config = {
+            "owner": "testuser",
+            "repositories": [
+                {"name": "my-app", "url": "https://gitlab.com/testuser/my-app.git"}
+            ]
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_config()
+            self.assertTrue(result)
+
+
+class TestNotificationValidation(unittest.TestCase):
+    """Test Discord webhook URL validation"""
+
+    @patch('validate.Path')
+    def test_valid_discord_webhook_url(self, mock_path):
+        """Test that valid Discord webhook URLs pass validation"""
+        from validate import validate_notifications
+
+        config = {
+            "settings": {
+                "notifications": {
+                    "enabled": True,
+                    "discord_webhook": "https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrstuvwxyz-ABCDEFGHIJKLMNOP"
+                }
+            }
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_notifications()
+            self.assertTrue(result)
+
+    @patch('validate.Path')
+    def test_valid_legacy_discord_webhook_url(self, mock_path):
+        """Test that legacy discordapp.com webhook URLs pass validation"""
+        from validate import validate_notifications
+
+        config = {
+            "settings": {
+                "notifications": {
+                    "enabled": True,
+                    "discord_webhook": "https://discordapp.com/api/webhooks/123456789012345678/abcdefghijklmnopqrstuvwxyz"
+                }
+            }
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_notifications()
+            self.assertTrue(result)
+
+    @patch('validate.Path')
+    def test_invalid_discord_webhook_url_rejected(self, mock_path):
+        """Test that invalid Discord webhook URLs are rejected"""
+        from validate import validate_notifications
+
+        config = {
+            "settings": {
+                "notifications": {
+                    "enabled": True,
+                    "discord_webhook": "https://example.com/webhook/123"
+                }
+            }
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_notifications()
+            self.assertFalse(result)
+
+    @patch('validate.Path')
+    def test_disabled_notifications_skip_validation(self, mock_path):
+        """Test that disabled notifications skip webhook validation"""
+        from validate import validate_notifications
+
+        config = {
+            "settings": {
+                "notifications": {
+                    "enabled": False,
+                    "discord_webhook": "invalid-url"
+                }
+            }
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_notifications()
+            self.assertTrue(result)
+
+    @patch('validate.Path')
+    def test_missing_webhook_with_notifications_enabled_warns(self, mock_path):
+        """Test that missing webhook URL with notifications enabled returns True (warning only)"""
+        from validate import validate_notifications
+
+        config = {
+            "settings": {
+                "notifications": {
+                    "enabled": True
+                }
+            }
+        }
+
+        mock_path.return_value.exists.return_value = True
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_notifications()
+            self.assertTrue(result)  # Non-critical warning
+
+
+class TestRepositoryAccessValidation(unittest.TestCase):
+    """Test repository accessibility validation"""
+
+    @patch('validate.run_cmd')
+    @patch('validate.Path')
+    def test_accessible_repositories_pass(self, mock_path, mock_run_cmd):
+        """Test that accessible repositories pass validation"""
+        from validate import validate_repository_access
+
+        config = {
+            "repositories": [
+                {"name": "my-app", "url": "https://github.com/testuser/my-app.git"}
+            ]
+        }
+
+        mock_path.return_value.exists.return_value = True
+        mock_run_cmd.return_value = (True, 'my-app', '')
+
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_repository_access()
+            self.assertTrue(result)
+
+    @patch('validate.run_cmd')
+    @patch('validate.Path')
+    def test_inaccessible_repositories_warn(self, mock_path, mock_run_cmd):
+        """Test that inaccessible repositories return True (warning only)"""
+        from validate import validate_repository_access
+
+        config = {
+            "repositories": [
+                {"name": "my-app", "url": "https://github.com/testuser/my-app.git"}
+            ]
+        }
+
+        mock_path.return_value.exists.return_value = True
+        mock_run_cmd.return_value = (False, '', 'Not found')
+
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_repository_access()
+            self.assertTrue(result)  # Non-critical warning
+
+    @patch('validate.run_cmd')
+    @patch('validate.Path')
+    def test_non_github_urls_skipped(self, mock_path, mock_run_cmd):
+        """Test that non-GitHub URLs skip accessibility check"""
+        from validate import validate_repository_access
+
+        config = {
+            "repositories": [
+                {"name": "my-app", "url": "https://gitlab.com/testuser/my-app.git"}
+            ]
+        }
+
+        mock_path.return_value.exists.return_value = True
+
+        with patch('builtins.open', unittest.mock.mock_open(read_data=json.dumps(config))):
+            result = validate_repository_access()
+            self.assertTrue(result)
+            # run_cmd should NOT be called for non-GitHub URLs
+            mock_run_cmd.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
Adds config validation improvements to catch misconfigurations at startup:
- Duplicate repository name detection  
- Repository URL format validation (GitHub, GitLab, Bitbucket, Azure DevOps)
- Discord webhook URL format validation
- Repository accessibility check (non-blocking warning)

## Evidence

### Problem: Missing Validation Gaps in `scripts/validate.py`

**Before this PR** (main branch, lines 76-82):
```python
for i, repo in enumerate(repos):
    if not repo.get('name'):
        err(f"Repository {i+1} missing 'name'")
        return False
    if not repo.get('url'):
        err(f"Repository '{repo.get('name')}' missing 'url'")
        return False
```

**Gaps identified:**
1. **No duplicate detection** - If user configures same repo name twice, confusing runtime errors occur
2. **No URL format validation** - Invalid URLs like `http://example.com/repo` pass validation but fail at clone time
3. **No Discord webhook validation** - Invalid webhook URLs fail silently during notification attempts
4. **No accessibility check** - Misconfigured repos not caught until agent execution

### Reproduction Steps (Before Fix)

1. **Duplicate names silently accepted:**
   ```json
   {"repositories": [
     {"name": "my-app", "url": "https://github.com/user/my-app.git"},
     {"name": "my-app", "url": "https://github.com/user/other.git"}
   ]}
   ```
   → Validation passes, but agents get confused at runtime

2. **Invalid URLs accepted:**
   ```json
   {"repositories": [{"name": "test", "url": "http://example.com/repo.git"}]}
   ```
   → Validation passes, git clone fails later

3. **Invalid Discord webhook accepted:**
   ```json
   {"settings": {"notifications": {"enabled": true, "discord_webhook": "https://example.com/hook"}}}
   ```
   → Validation passes, notifications fail silently

### After This PR

All above cases now fail validation at startup with clear error messages:
- `"Duplicate repository names: my-app"`
- `"Repository 'test' has invalid URL format"`
- `"Invalid Discord webhook URL format"`

## Changes
- `scripts/validate.py:77-84` - Duplicate repository name detection
- `scripts/validate.py:86-115` - Repository URL format validation with regex
- `scripts/validate.py:390-429` - Discord webhook URL format validation
- `scripts/validate.py:432-480` - Repository accessibility check (warning)
- `tests/test_validate.py` - 13 new test cases (all 18 tests pass)

## Test Results
```
$ pytest tests/test_validate.py -v
18 passed in 0.05s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)