### PR TITLE
fix: handle null headRefName in PR detection to prevent AttributeError

### DIFF
--- a/src/barbossa/agents/auditor.py
+++ b/src/barbossa/agents/auditor.py
@@ -164,7 +164,7 @@ class BarbossaAuditor:
             barbossa_prs = []
 
             for pr in prs:
-                if not pr.get('headRefName', '').startswith('barbossa/'):
+                if not (pr.get('headRefName') or '').startswith('barbossa/'):
                     continue
 
                 created_str = pr.get('createdAt', '')

--- a/src/barbossa/agents/engineer.py
+++ b/src/barbossa/agents/engineer.py
@@ -602,7 +602,7 @@ See: {output_file}
         for pr in prs:
             # CRITICAL: Only work on Barbossa-created PRs
             # This prevents modifying human contributor PRs
-            branch = pr.get('headRefName', '')
+            branch = pr.get('headRefName') or ''
             if not branch.startswith('barbossa/'):
                 self.logger.debug(f"  PR #{pr.get('number')}: Skipping - not a Barbossa PR (branch: {branch})")
                 continue
@@ -736,7 +736,7 @@ See: {output_file}
         owner = self.owner
         repo_name = repo['name']
         pr_number = pr['number']
-        pr_branch = pr['headRefName']
+        pr_branch = pr.get('headRefName') or 'unknown'
         attention_reason = pr.get('attention_reason', 'needs_review')
 
         pkg_manager = repo.get('package_manager', 'npm')

--- a/src/barbossa/agents/tech_lead.py
+++ b/src/barbossa/agents/tech_lead.py
@@ -579,7 +579,7 @@ class BarbossaTechLead:
         prompt = prompt.replace("{{pr_author}}", pr.get('author', {}).get('login', 'unknown'))
         prompt = prompt.replace("{{pr_created}}", pr.get('createdAt', 'unknown'))
         prompt = prompt.replace("{{pr_updated}}", pr.get('updatedAt', 'unknown'))
-        prompt = prompt.replace("{{pr_branch}}", pr.get('headRefName', 'unknown'))
+        prompt = prompt.replace("{{pr_branch}}", pr.get('headRefName') or 'unknown')
         prompt = prompt.replace("{{pr_additions}}", str(pr.get('additions', 0)))
         prompt = prompt.replace("{{pr_deletions}}", str(pr.get('deletions', 0)))
         prompt = prompt.replace("{{pr_files_changed}}", str(pr.get('changedFiles', 0)))
@@ -1205,7 +1205,7 @@ _Senior Engineer: Please address the above feedback and push updates._"""
             except ValueError:
                 age_days = 0  # Invalid date format, assume not stale
 
-            branch = pr.get('headRefName', '')
+            branch = pr.get('headRefName') or ''
             is_barbossa_pr = branch.startswith('barbossa/')
 
             if is_barbossa_pr and age_days >= STALE_DAYS:
@@ -1283,7 +1283,7 @@ _Senior Engineer: Please address the above feedback and push updates._"""
 
             # Filter to only Barbossa-created PRs (branch starts with 'barbossa/')
             # This prevents reviewing/modifying human contributor PRs
-            barbossa_prs = [pr for pr in open_prs if pr.get('headRefName', '').startswith('barbossa/')]
+            barbossa_prs = [pr for pr in open_prs if (pr.get('headRefName') or '').startswith('barbossa/')]
             skipped_count = len(open_prs) - len(barbossa_prs)
 
             if skipped_count > 0:

--- a/tests/test_headrefname_edge_cases.py
+++ b/tests/test_headrefname_edge_cases.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Tests for headRefName edge case handling in agents.
+
+Verifies that agents correctly handle PRs with None/null headRefName values
+from the GitHub API. This prevents AttributeError crashes when GitHub returns
+unexpected data.
+
+Issue: dict.get('headRefName', '') returns None (not '') when the key exists
+with an explicit None value. Calling .startswith() on None raises AttributeError.
+Fix: Use (pr.get('headRefName') or '') pattern.
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add src directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+
+class TestHeadRefNameEdgeCases(unittest.TestCase):
+    """Test headRefName None handling across agents."""
+
+    def setUp(self):
+        """Create temp directory with valid config."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.config_dir = self.temp_dir / 'config'
+        self.config_dir.mkdir()
+        self.projects_dir = self.temp_dir / 'projects'
+        self.projects_dir.mkdir()
+        self.config_path = self.config_dir / 'repositories.json'
+        self.valid_config = {
+            'owner': 'test-owner',
+            'repositories': [
+                {'name': 'test-repo', 'url': 'https://github.com/test/test'}
+            ]
+        }
+        self.config_path.write_text(json.dumps(self.valid_config))
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _create_engineer(self):
+        """Create an Engineer instance with mocked dependencies."""
+        from barbossa.agents.engineer import Barbossa
+
+        with patch('barbossa.agents.engineer.logging') as mock_logging, \
+             patch('barbossa.agents.engineer.process_retry_queue'):
+            mock_logger = MagicMock()
+            mock_logging.getLogger.return_value = mock_logger
+            mock_logging.INFO = 20
+            mock_logging.FileHandler = MagicMock()
+            mock_logging.StreamHandler = MagicMock()
+
+            engineer = Barbossa(work_dir=self.temp_dir)
+            return engineer
+
+    def _make_pr_with_headref(self, pr_number: int, head_ref_name) -> dict:
+        """Helper to create a PR dict with specific headRefName value."""
+        return {
+            'number': pr_number,
+            'headRefName': head_ref_name,
+            'title': 'Test PR',
+            'reviewDecision': None,
+            'mergeable': 'MERGEABLE',
+            'mergeStateStatus': 'CLEAN',
+            'statusCheckRollup': []
+        }
+
+    @patch('barbossa.agents.engineer.Barbossa._get_open_prs')
+    @patch('barbossa.agents.engineer.Barbossa._get_pr_comments')
+    def test_null_headrefname_skips_pr(self, mock_comments, mock_prs):
+        """PR with headRefName=None should be skipped without crashing."""
+        engineer = self._create_engineer()
+        repo = {'name': 'test-repo', 'url': 'https://github.com/test/test'}
+
+        # headRefName is explicitly null (not missing key)
+        mock_prs.return_value = [self._make_pr_with_headref(1, None)]
+        mock_comments.return_value = []
+
+        # Should not raise AttributeError
+        result = engineer._get_prs_needing_attention(repo)
+
+        # PR with None branch should be skipped (not a barbossa PR)
+        self.assertEqual(len(result), 0)
+
+    @patch('barbossa.agents.engineer.Barbossa._get_open_prs')
+    @patch('barbossa.agents.engineer.Barbossa._get_pr_comments')
+    def test_missing_headrefname_key_skips_pr(self, mock_comments, mock_prs):
+        """PR without headRefName key should be skipped without crashing."""
+        engineer = self._create_engineer()
+        repo = {'name': 'test-repo', 'url': 'https://github.com/test/test'}
+
+        # Create PR without headRefName key
+        pr = {'number': 1, 'title': 'Test PR', 'statusCheckRollup': []}
+        mock_prs.return_value = [pr]
+        mock_comments.return_value = []
+
+        # Should not raise KeyError or AttributeError
+        result = engineer._get_prs_needing_attention(repo)
+
+        # PR with missing branch should be skipped
+        self.assertEqual(len(result), 0)
+
+    @patch('barbossa.agents.engineer.Barbossa._get_open_prs')
+    @patch('barbossa.agents.engineer.Barbossa._get_pr_comments')
+    def test_empty_string_headrefname_skips_pr(self, mock_comments, mock_prs):
+        """PR with headRefName='' should be skipped."""
+        engineer = self._create_engineer()
+        repo = {'name': 'test-repo', 'url': 'https://github.com/test/test'}
+
+        mock_prs.return_value = [self._make_pr_with_headref(1, '')]
+        mock_comments.return_value = []
+
+        result = engineer._get_prs_needing_attention(repo)
+
+        # Empty string doesn't start with 'barbossa/'
+        self.assertEqual(len(result), 0)
+
+    @patch('barbossa.agents.engineer.Barbossa._get_open_prs')
+    @patch('barbossa.agents.engineer.Barbossa._get_pr_comments')
+    def test_valid_barbossa_branch_detected(self, mock_comments, mock_prs):
+        """PR with valid barbossa/ branch should be detected."""
+        engineer = self._create_engineer()
+        repo = {'name': 'test-repo', 'url': 'https://github.com/test/test'}
+
+        mock_prs.return_value = [self._make_pr_with_headref(1, 'barbossa/20260105-test')]
+        mock_comments.return_value = []
+
+        result = engineer._get_prs_needing_attention(repo)
+
+        # Valid barbossa branch should be detected (might need attention for other reasons)
+        # but importantly, no crash occurred
+        self.assertTrue(True)  # No exception = pass
+
+    @patch('barbossa.agents.engineer.Barbossa._get_open_prs')
+    @patch('barbossa.agents.engineer.Barbossa._get_pr_comments')
+    def test_mixed_null_and_valid_branches(self, mock_comments, mock_prs):
+        """List with mix of null and valid branches should process correctly."""
+        engineer = self._create_engineer()
+        repo = {'name': 'test-repo', 'url': 'https://github.com/test/test'}
+
+        mock_prs.return_value = [
+            self._make_pr_with_headref(1, None),
+            self._make_pr_with_headref(2, 'barbossa/valid'),
+            self._make_pr_with_headref(3, ''),
+            self._make_pr_with_headref(4, 'feature/other'),
+        ]
+        mock_comments.return_value = []
+
+        # Should process all without crashing
+        result = engineer._get_prs_needing_attention(repo)
+
+        # Only barbossa/valid should potentially be in results
+        # All others should be skipped
+        for pr in result:
+            self.assertTrue(
+                (pr.get('headRefName') or '').startswith('barbossa/'),
+                f"Non-barbossa PR should not be in results: {pr}"
+            )
+
+
+class TestTechLeadHeadRefNameEdgeCases(unittest.TestCase):
+    """Test headRefName None handling in Tech Lead agent."""
+
+    def setUp(self):
+        """Create temp directory with valid config."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.config_dir = self.temp_dir / 'config'
+        self.config_dir.mkdir()
+        self.projects_dir = self.temp_dir / 'projects'
+        self.projects_dir.mkdir()
+        self.config_path = self.config_dir / 'repositories.json'
+        self.valid_config = {
+            'owner': 'test-owner',
+            'repositories': [
+                {'name': 'test-repo', 'url': 'https://github.com/test/test'}
+            ]
+        }
+        self.config_path.write_text(json.dumps(self.valid_config))
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _create_tech_lead(self):
+        """Create a BarbossaTechLead instance with mocked dependencies."""
+        from barbossa.agents.tech_lead import BarbossaTechLead
+
+        with patch('barbossa.agents.tech_lead.logging') as mock_logging, \
+             patch('barbossa.agents.tech_lead.process_retry_queue'):
+            mock_logger = MagicMock()
+            mock_logging.getLogger.return_value = mock_logger
+            mock_logging.INFO = 20
+            mock_logging.FileHandler = MagicMock()
+            mock_logging.StreamHandler = MagicMock()
+
+            tech_lead = BarbossaTechLead(work_dir=self.temp_dir)
+            return tech_lead
+
+    def _make_pr(self, pr_number: int, head_ref_name, created_at: str = '2026-01-01T00:00:00Z') -> dict:
+        """Helper to create a PR dict."""
+        return {
+            'number': pr_number,
+            'headRefName': head_ref_name,
+            'title': 'Test PR',
+            'createdAt': created_at,
+            'state': 'OPEN'
+        }
+
+    def test_filter_barbossa_prs_handles_null(self):
+        """Filter logic should handle null headRefName without crashing."""
+        prs = [
+            self._make_pr(1, None),
+            self._make_pr(2, 'barbossa/test'),
+            self._make_pr(3, ''),
+            self._make_pr(4, 'feature/other'),
+        ]
+
+        # Using the fixed pattern: (pr.get('headRefName') or '').startswith('barbossa/')
+        barbossa_prs = [pr for pr in prs if (pr.get('headRefName') or '').startswith('barbossa/')]
+
+        self.assertEqual(len(barbossa_prs), 1)
+        self.assertEqual(barbossa_prs[0]['number'], 2)
+
+    def test_cleanup_stale_prs_handles_null(self):
+        """Stale PR cleanup should handle null headRefName."""
+        tech_lead = self._create_tech_lead()
+
+        prs = [
+            self._make_pr(1, None, '2020-01-01T00:00:00Z'),  # Very old but null branch
+            self._make_pr(2, 'barbossa/test', '2020-01-01T00:00:00Z'),  # Old barbossa PR
+            self._make_pr(3, 'feature/other', '2020-01-01T00:00:00Z'),  # Old non-barbossa PR
+        ]
+
+        # Verify the pattern works for each PR
+        for pr in prs:
+            branch = pr.get('headRefName') or ''
+            is_barbossa_pr = branch.startswith('barbossa/')
+            # Should not raise AttributeError
+            if pr['number'] == 2:
+                self.assertTrue(is_barbossa_pr)
+            else:
+                self.assertFalse(is_barbossa_pr)
+
+
+class TestAuditorHeadRefNameEdgeCases(unittest.TestCase):
+    """Test headRefName None handling in Auditor agent."""
+
+    def test_filter_barbossa_prs_handles_null(self):
+        """Auditor filter logic should handle null headRefName."""
+        prs = [
+            {'number': 1, 'headRefName': None, 'createdAt': '2026-01-01T00:00:00Z'},
+            {'number': 2, 'headRefName': 'barbossa/test', 'createdAt': '2026-01-01T00:00:00Z'},
+            {'number': 3, 'headRefName': '', 'createdAt': '2026-01-01T00:00:00Z'},
+        ]
+
+        # Using the fixed pattern
+        barbossa_prs = []
+        for pr in prs:
+            if not (pr.get('headRefName') or '').startswith('barbossa/'):
+                continue
+            barbossa_prs.append(pr)
+
+        self.assertEqual(len(barbossa_prs), 1)
+        self.assertEqual(barbossa_prs[0]['number'], 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes edge case where GitHub API returns `headRefName` as explicitly `null` instead of missing
- When `headRefName` is `null`, `dict.get('headRefName', '')` returns `None` (not the default `''`)
- Calling `.startswith()` on `None` raises `AttributeError`, crashing the agent

## Evidence
- **File references**: 
  - `src/barbossa/agents/engineer.py:605` - PR filtering uses `.get('headRefName', '').startswith()`
  - `src/barbossa/agents/engineer.py:739` - Direct key access `pr['headRefName']` risks `KeyError`
  - `src/barbossa/agents/tech_lead.py:582, 1208, 1286` - Same pattern in Tech Lead agent
  - `src/barbossa/agents/auditor.py:167` - Same pattern in Auditor agent
- **Reproduction**: If GitHub API returns `{"headRefName": null}` instead of omitting the key, all agents would crash with `AttributeError: 'NoneType' object has no attribute 'startswith'`

## Dependencies
- Lockfile changes: NO
- Dependency changes: NONE

## Changes
- Changed all `pr.get('headRefName', '')` to `pr.get('headRefName') or ''` pattern
- Changed `pr['headRefName']` to `pr.get('headRefName') or 'unknown'` in engineer.py
- Added comprehensive unit tests covering:
  - `headRefName` is `None`
  - `headRefName` key is missing
  - `headRefName` is empty string
  - Mixed scenarios with multiple PRs

## Testing
- All 8 new edge case tests pass
- Full test suite (139 tests) passes without regression
- Pattern tested: `(value or '').startswith('prefix/')` safely handles `None`, missing keys, and empty strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)